### PR TITLE
Add waiting time to test just after startup.

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -375,6 +375,11 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 	// Tests always wait until the game is fully loaded.
 	if(!GameData::IsLoaded())
 		return;
+	if(context.startupWait)
+	{
+		--(context.startupWait);
+		return;
+	}
 		
 	if(status == Status::BROKEN)
 		Fail(context, player, "Test has a broken status.");

--- a/source/TestContext.h
+++ b/source/TestContext.h
@@ -31,6 +31,8 @@ private:
 	// Pointer to the test we are running.
 	std::vector<const Test *> testToRun;
 	
+	int startupWait = 20;
+	
 	// Teststep to run.
 	std::vector<unsigned int> stepToRun = { 0 };
 	unsigned int watchdog = 0;


### PR DESCRIPTION
This change fixes one of the two failing integration tests by allowing the game some time to reset player data before the test starts.
This PR is mostly created as an example, I expect that we might want to use a better mechanism than just waiting 20 steps.