### PR TITLE
Fix for testing on complete data and fix for the saving test.

### DIFF
--- a/data/tests/tests_save_load.txt
+++ b/data/tests/tests_save_load.txt
@@ -57,15 +57,18 @@ test "Loading and Saving"
 		label notAlpha1
 		branch notAlpha1
 			not "flagship system: Alpha Centauri"
+		# Terminate jumping if it still is active.
+		input
+			command forward
 		navigate
 			travel "Sol"
 			"travel destination" Earth
+		input
+			command jump
 		watchdog 12000
 		label notReturned1
 		branch notReturned1
 			not "flagship planet: Earth"
-		apply
-			"test: day" = day
 		assert
 			year == 3013
 			month == 11

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -374,7 +374,12 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 {
 	if(status == Status::BROKEN)
 		Fail(context, player, "Test has a broken status.");
-
+	
+	// Only run tests when all data is loaded. Panels like MenuPanel don't accept input
+	// when not all data is loaded yet.
+	if(!GameData::IsLoaded())
+		return;
+	
 	// Track if we need to return to the main gameloop.
 	bool continueGameLoop = false;
 	


### PR DESCRIPTION
**Bugfix:** This PR addresses testing on incomplete data and a bug in a test

## Fix Details
The test-framework needs to wait until all GameData is loaded, otherwise panels like GameMenu will ignore input that was given.

## Testing Done
Executed the integration tests.

## Save File
N/A